### PR TITLE
Add preview bot environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ deno task start
 
 This will watch the project directory and restart as necessary.
 
+### Deploy to Preview 
+
+1. Make changes in some branch 
+2. Run `deno task deploy-preview` to push changes to the preview system 
+3. Find the changes here: [https://deno-audio-logbook-preview.deno.dev/auth/login](https://deno-audio-logbook-preview.deno.dev/auth/login)
+
+Note: This Preview system is mostly intendend to test stuff related to the telegram bot functions, 
+because it has a second bot attached to it's url, named: audio_logbook_preview_bot
+
 ### Connect to DB locally 
 
 Prerequisites: 
@@ -49,7 +58,10 @@ Now you can connect to `localhost:3306` with user root and no password with any 
 ## Infrastructure 
 
 - Dev Environment: http://localhost:8000/
-- Prod Environemtn: https://deno-audio-logbook.deno.dev/
+- Prod Environment: https://deno-audio-logbook.deno.dev/
+- Prod Telegram Bot Name: audio_logbook_bot
+- Explicit Preview Environment: https://deno-audio-logbook-preview.deno.dev/auth/login
+- Explicit Preview Telegram Bot Name: audio_logbook_preview_bot
 
 
 - Deno Deploy Dashboard: https://dash.deno.com/projects/deno-audio-logbook

--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,8 @@
     "esm:add": "deno run -A https://esm.sh/v110 add",
     "esm:update": "deno run -A https://esm.sh/v110 update",
     "esm:remove": "deno run -A https://esm.sh/v110 remove",
-    "download-openprops": "deno run --allow-net --allow-write --allow-read ./scripts/download-openprops.ts"
+    "download-openprops": "deno run --allow-net --allow-write --allow-read ./scripts/download-openprops.ts",
+    "deploy-preview": "deno run -A https://deno.land/x/git_deploy@2.0.0-preview.6/cli.ts --target origin --branch preview"
   },
   "importMap": "./import_map.json",
   "compilerOptions": {

--- a/routes/auth/login.tsx
+++ b/routes/auth/login.tsx
@@ -29,6 +29,7 @@ export async function handler(
 export default function Login(props: PageProps<{ telegramBotUser: string }>) {
   return (
     <Layout h1Override="Audio Logbook - Login">
+      <h2>Test</h2>
       <div style="margin: 0 auto; width: min-content; ">
         <script
           async

--- a/routes/auth/login.tsx
+++ b/routes/auth/login.tsx
@@ -29,7 +29,6 @@ export async function handler(
 export default function Login(props: PageProps<{ telegramBotUser: string }>) {
   return (
     <Layout h1Override="Audio Logbook - Login">
-      <h2>Test</h2>
       <div style="margin: 0 auto; width: min-content; ">
         <script
           async

--- a/routes/auth/login.tsx
+++ b/routes/auth/login.tsx
@@ -1,7 +1,8 @@
-import { HandlerContext, Handlers } from "$fresh/server.ts";
-import { Head } from "$fresh/runtime.ts";
-import { DEPLOYMENT_ID } from "@/src/const/server_constants.ts";
+import { HandlerContext, PageProps } from "$fresh/server.ts";
 import Layout from "@/components/Layout.tsx";
+import { secretsPromise } from "@/src/utils/secrets.ts";
+
+const secrets = await secretsPromise;
 
 export async function handler(
   req: Request,
@@ -20,17 +21,19 @@ export async function handler(
   //     }
   //   }
 
-  return await ctx.render();
+  return await ctx.render({
+    telegramBotUser: secrets.get("TELEGRAM_BOT_USER"),
+  });
 }
 
-export default function Login() {
+export default function Login(props: PageProps<{ telegramBotUser: string }>) {
   return (
     <Layout h1Override="Audio Logbook - Login">
       <div style="margin: 0 auto; width: min-content; ">
         <script
           async
           src="https://telegram.org/js/telegram-widget.js?21"
-          data-telegram-login="audio_logbook_bot"
+          data-telegram-login={props.data.telegramBotUser}
           data-size="large"
           data-auth-url="/auth/callback"
           data-request-access="write"


### PR DESCRIPTION
I've added a preview environment for audio logbook, 
basically a second deno deployment (to have a stable preview address), 
in combination with a second Telegram Bot (see Readme changes for more info) 